### PR TITLE
stop attempts to display major buildings on z10 z11, special display across all levels

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -1,23 +1,15 @@
 @building-fill: #dcd5c6;
 @building-line: darken(@building-fill, 10%);
 
+@building-major-fill: darken(@building-fill, 20%);
+@building-major-line: darken(@building-major-fill, 25%);
+
 @building-aeroway-fill: #cc99ff;
 @building-aeroway-line: darken(@building-aeroway-fill,15%);
 
 
-#buildings-major {
-  [zoom >= 10][zoom < 12] {
-    polygon-fill: @building-fill;
-    polygon-clip: false;
-  }
-}
-
 #buildings {
   [zoom >= 12] {
-    /* Set the base styling for buildings. We'll need to reset the fill and
-       line colours for more specialized building rendering lower down, but
-       not the clipping or line-width.
-    */
     polygon-fill: @building-fill;
     polygon-clip: false;
     [zoom >= 15] {
@@ -25,10 +17,27 @@
       line-width: .75;
       line-clip: false;
     }
+  }
+}
+
+#buildings-major {
+  [zoom >= 12] {
     [aeroway = 'terminal'] {
       polygon-fill: @building-aeroway-fill;
+      polygon-clip: false;
       [zoom >= 15] {
+        line-width: .75;
+        line-clip: false;
         line-color: @building-aeroway-line;
+      }
+    }
+    [amenity = 'place_of_worship'] {
+      polygon-fill: @building-major-fill;
+      polygon-clip: false;
+      [zoom >= 15] {
+        line-width: .75;
+        line-clip: false;
+        line-color: @building-major-line;
       }
     }
   }

--- a/project.mml
+++ b/project.mml
@@ -354,29 +354,6 @@
       "advanced": {}
     }, 
     {
-      "name": "buildings-major", 
-      "srs-name": "900913", 
-      "geometry": "polygon", 
-      "class": "", 
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT way, building, amenity\n  FROM planet_osm_polygon\n  WHERE building IN ('station','supermarket')\n    OR (building IS NOT NULL AND building != 'no'\n      AND (\n        amenity IN ('place_of_worship','supermarket') OR shop = 'mall' OR tourism = 'attraction'\n      )\n    )\n  ORDER BY z_order,way_area DESC)\nAS buildings_major", 
-        "geometry_field": "way", 
-        "type": "postgis", 
-        "key_field": "", 
-        "dbname": "gis"
-      }, 
-      "extent": [
-        -180, 
-        -85.05112877980659, 
-        180, 
-        85.05112877980659
-      ], 
-      "id": "buildings-major", 
-      "advanced": {}
-    }, 
-    {
       "name": "buildings", 
       "srs-name": "900913", 
       "geometry": "polygon", 
@@ -384,7 +361,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT\n    way, name, building, amenity, aeroway, way_area\n  FROM planet_osm_polygon\n  WHERE (building IS NOT NULL OR aeroway = 'terminal')\n    AND building != 'no'\n  ORDER BY z_order, way_area DESC\n) AS buildings", 
+        "table": "(SELECT\n    way, building\n  FROM planet_osm_polygon\n  WHERE (building IS NOT NULL)\n    AND building != 'no'\n  ORDER BY z_order, way_area DESC\n) AS buildings", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 
@@ -397,6 +374,29 @@
         85.05112877980659
       ], 
       "id": "buildings", 
+      "advanced": {}
+    }, 
+    {
+      "name": "buildings-major", 
+      "srs-name": "900913", 
+      "geometry": "polygon", 
+      "class": "", 
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508", 
+        "table": "(SELECT way, building, amenity, aeroway\n  FROM planet_osm_polygon\n  WHERE (building IS NOT NULL)\n    AND building != 'no'\n  ORDER BY z_order,way_area DESC)\nAS buildings_major", 
+        "geometry_field": "way", 
+        "type": "postgis", 
+        "key_field": "", 
+        "dbname": "gis"
+      }, 
+      "extent": [
+        -180, 
+        -85.05112877980659, 
+        180, 
+        85.05112877980659
+      ], 
+      "id": "buildings-major", 
       "advanced": {}
     }, 
     {

--- a/project.yaml
+++ b/project.yaml
@@ -295,25 +295,6 @@ Layer:
           WHERE waterway = 'lock_gate'
         ) AS locks
     advanced: {}
-  - id: "buildings-major"
-    name: "buildings-major"
-    class: ""
-    geometry: "polygon"
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT way, building, amenity
-          FROM planet_osm_polygon
-          WHERE building IN ('station','supermarket')
-            OR (building IS NOT NULL AND building != 'no'
-              AND (
-                amenity IN ('place_of_worship','supermarket') OR shop = 'mall' OR tourism = 'attraction'
-              )
-            )
-          ORDER BY z_order,way_area DESC)
-        AS buildings_major
-    advanced: {}
   - id: "buildings"
     name: "buildings"
     class: ""
@@ -323,12 +304,27 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, name, building, amenity, aeroway, way_area
+            way, building
           FROM planet_osm_polygon
-          WHERE (building IS NOT NULL OR aeroway = 'terminal')
+          WHERE (building IS NOT NULL)
             AND building != 'no'
           ORDER BY z_order, way_area DESC
         ) AS buildings
+    advanced: {}
+  - id: "buildings-major"
+    name: "buildings-major"
+    class: ""
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT way, building, amenity, aeroway
+          FROM planet_osm_polygon
+          WHERE (building IS NOT NULL)
+            AND building != 'no'
+          ORDER BY z_order,way_area DESC)
+        AS buildings_major
     advanced: {}
   - id: "tunnels"
     name: "tunnels"


### PR DESCRIPTION
even the largest building in the world by footprint would be barely visible on z10 z11 so old building_major layer was not useful
now major buildings (place_of_worship for start) are displayed specially across all zoom levels with visible buildings
separate layer is necessary to ensure that building line of major building will be rendered on top of building line of touching building
note that major buildings will be rendered on top of not major buildings, including major buildings with lower layer tag
note that now aeroway terminal without building tag now will not be displayed

![selection_002](https://cloud.githubusercontent.com/assets/899988/4741651/61f6b5ee-5a18-11e4-93ea-06f0c1e71623.png)
